### PR TITLE
fix: processes kwarg always >0

### DIFF
--- a/lig3dlens/alignment.py
+++ b/lig3dlens/alignment.py
@@ -51,8 +51,7 @@ def run_alignment(
         output_file = Path(output_file)
         w = Chem.SDWriter(str(output_file))
 
-    num_processes = multiprocessing.cpu_count() - 2
-    with multiprocessing.Pool(num_processes) as pool:
+    with multiprocessing.Pool() as pool:
         try:
             for mol_id, mol in pool.imap_unordered(
                 map_conf_gen,


### PR DESCRIPTION
If a machine has 2 or fewer CPU cores, then the line

```
    num_processes = multiprocessing.cpu_count() - 2
    with multiprocessing.Pool(num_processes) as pool:
```
will always cause a `ValueError: Number of processes must be at least 1` as described in #15 

This PR fixes the issue by accepting the default safe behaviour of `mutliprocessing.Pool`