### PR TITLE
build(ci): regular CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,18 @@ workflows:
     jobs:
       - build
 
+  weekly:
+    jobs:
+      - build
+    triggers:
+      - schedule:
+          # run at 00:30 every Sunday
+          cron: "30 0 * * 0"
+          filters:
+            branches:
+              only:
+                - main
+
 jobs:
   build:
     docker:


### PR DESCRIPTION
This PR adds a regular build to the repo (on Sundays at 00:30) -- this should raise our awareness of build / packaging issues before end users experience issues. 