### PR TITLE
feat: add --no-filter option to bypass physicochemical filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Bill Tatsis, Matt Seddon, Dan Mason, Dan O'Donovan, Gio Cincilla, Azedine Zoufir
 
 Lig3DLens performs the following tasks:
 1. Prepares a commercial compound library to be used for a VS campaign. This task
-involves: i) compound standardisation and ii) filtering out compounds outside a predefined range of physicochemical properties.
+involves: i) compound standardisation and ii) optional filtering of compounds outside a predefined range of physicochemical properties.
 2. Generates conformers for all of the compounds in the commercial library and calculates their 3D similarity (shape & electrostatics) to a reference compound.
 3. Finally, it can cluster the highest scoring hits and select a set number of representative compounds that can be ordered and tested.
 
@@ -31,9 +31,16 @@ tox
 > **Note**
 > In order to keep track of the library cmpds the input file should have a column containing the text "ID"
 
+**With physicochemical filtering (default):**
 ```
-lig3lens-prepare --in input_SD_file --filter physchem_yaml_file --out output_SD_file
+lig3dlens-prepare --in input_SD_file --filter physchem_yaml_file --out output_SD_file
 ```
+
+**Without filtering (standardization only):**
+```
+lig3dlens-prepare --in input_SD_file --no-filter --out output_SD_file
+```
+Use `--no-filter` when filtering has already been performed or when no filtering is desired. This significantly improves performance by skipping descriptor calculations.
 
 2. Generates 3D conformers for both the library and reference compounds and scores the library compounds using a 3D shape & electrostatics similarity function to the reference molecule
 > **Note**
@@ -58,11 +65,18 @@ lig3dlens-cluster –-in input_SD_file –-clusters num_clusters –-out output_
 ### Example
 To run `lig3dlens` with the input files (reference molecule and compound library) included in this repository;
 
-... preparing the compound library for virtual screening
+... preparing the compound library for virtual screening (with filtering)
 ```shell
 lig3dlens-prepare --in tests/test_data/Enamine_hts_collection_202303_first500_VS_results.sdf \
     --filter lig3dlens/physchem_properties.yaml \
-    --out curated_compounds.sd
+    --out curated_compounds.sdf
+```
+
+... or without filtering (standardization only, faster)
+```shell
+lig3dlens-prepare --in tests/test_data/Enamine_hts_collection_202303_first500_VS_results.sdf \
+    --no-filter \
+    --out standardized_compounds.sdf
 ```
 
 ... generate the 3D conformers for both reference and library compounds, score the compounds in the library set using a 3D shape and electrostatics similarity

--- a/tests/test_prep_cmpd_library.py
+++ b/tests/test_prep_cmpd_library.py
@@ -1,7 +1,8 @@
 import pandas as pd
 import pytest
+from click.testing import CliRunner
 
-from lig3dlens.prep_cmpd_library import _calculate_descriptors
+from lig3dlens.prep_cmpd_library import _calculate_descriptors, main
 
 
 class TestCalculateDescriptors:
@@ -33,3 +34,43 @@ class TestCalculateDescriptors:
             "heavy_atms",
             "stereo_cntrs",
         ]
+
+
+class TestPrepCmdLibraryCLI:
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    def test_no_options_provided_raises_error(self):
+        """Test that missing both --filter and --no-filter raises error"""
+        runner = CliRunner()
+        result = runner.invoke(main, ["--in", "dummy.sdf", "--out", "dummy_out.sdf"])
+
+        # Should fail with specific error message
+        assert result.exit_code == 1
+        assert (
+            "Must provide either --filter <yaml_file> or --no-filter" in result.output
+        )
+
+    def test_help_shows_new_options(self):
+        """Test that help text shows both filter options"""
+        runner = CliRunner()
+        result = runner.invoke(main, ["--help"])
+
+        assert result.exit_code == 0
+        assert "--filter" in result.output
+        assert "--no-filter" in result.output
+        assert "Skip physicochemical property filtering entirely" in result.output
+
+    def test_no_filter_flag_validation(self):
+        """Test that --no-filter flag is properly recognized"""
+        runner = CliRunner()
+        # This will fail due to missing input file, but should pass validation
+        result = runner.invoke(
+            main, ["--in", "nonexistent.sdf", "--no-filter", "--out", "dummy_out.sdf"]
+        )
+
+        # Should fail on file not found, not on validation
+        assert result.exit_code == 1
+        # Should not see the validation error message
+        assert "Must provide either --filter" not in result.output


### PR DESCRIPTION
Resolves #25 - Add ability to bypass physicochemical property filtering in lig3dlens-prepare command.

Changes:
- Add --no-filter CLI flag to prep_cmpd_library.py
- Skip descriptor calculation when --no-filter is used (performance improvement)
- Add validation to require either --filter or --no-filter
- Update README.md with usage examples and documentation
- Add comprehensive unit tests for new functionality

Usage:
  lig3dlens-prepare --in compounds.sdf --no-filter --out standardized.sdf