### PR TITLE
[DOD 789] Skip invalid SMILES

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 tidy:
+	ruff check --fix lig3dlens tests setup.py
 	isort lig3dlens tests setup.py --profile black
 	black lig3dlens tests setup.py
 

--- a/tests/test_prep_cmpd_library.py
+++ b/tests/test_prep_cmpd_library.py
@@ -1,15 +1,32 @@
 import pandas as pd
-import pytest
 
 from lig3dlens.prep_cmpd_library import _calculate_descriptors
 
 
 class TestCalculateDescriptors:
-    def test_invalid_smiles_raises_value_error(self):
+    def test_invalid_smiles_returns_none(self):
         sr = pd.Series({"test-col": "O=C([N-]c1cn+no1)C1CCCCC1"})
 
-        with pytest.raises(ValueError, match="Invalid SMILES"):
-            _calculate_descriptors(0, sr, smiles_column="test-col")
+        # Should return None instead of raising exception
+        result = _calculate_descriptors(0, sr, smiles_column="test-col")
+        assert result is None
+
+    def test_complex_heterocyclic_smiles_handling(self):
+        """Test handling of complex heterocyclic SMILES that may cause RDKit parsing issues
+
+        This tests a specific SMILES structure (thiazolo-pyrimidine nucleoside) that was
+        reported to cause the prep_cmpd_library script to stall during processing.
+        The function should gracefully handle any parsing failures by returning None
+        rather than raising exceptions that halt the entire workflow.
+        """
+        # SMILES for a thiazolo-pyrimidine nucleoside that caused processing issues
+        problematic_smiles = "O=c1cc(=O)n2ccsc2n1C1OC(CO)C(O)C1O"
+        sr = pd.Series({"smiles_sdt": problematic_smiles})
+
+        # This should not crash and should return None for invalid SMILES
+        result = _calculate_descriptors(0, sr, smiles_column="smiles_sdt")
+        # If the SMILES is actually valid, result should be a Series; if invalid, should be None
+        assert result is None or isinstance(result, pd.Series)
 
     def test_mesoionic_smiles(self):
         sr = pd.Series({"test-col": "O=[S](=O)([O-])[NH3+]"})


### PR DESCRIPTION
cf #28 

  - The `_calculate_descriptors` function was raising `ValueError` exceptions for invalid SMILES
  - This caused the parallel processing (`dm.parallelized`) to fail completely and halt the entire
  workflow
  - Users couldn't process large datasets containing some invalid molecular structures

 ## Solution Implemented

  1. Modified `_calculate_descriptors` function:
    - Returns `None` instead of raising `ValueError` for invalid SMILES
    - Added try-catch block to handle any descriptor calculation failures gracefully
    - Added informative warning logs for skipped molecules
  2. Enhanced `_preprocess` function:
    - Added robust error handling for each step of molecular standardization
    - Returns `None` for molecules that fail at any processing step
    - Provides detailed warning messages for debugging
  3. Updated parallel processing logic:
    - Filters out `None` results after both standardization and descriptor calculation
    - Added informative logging about how many compounds were successfully processed
    - Added safety checks for empty DataFrames
  4. Added comprehensive error handling:
    - Graceful handling of edge cases (empty DataFrames, missing columns)
    - Clear error messages when no valid compounds survive processing
  5. Enhanced testing:
    - Updated tests to verify `None` return instead of exception raising
    - Added specific test for the problematic SMILES structure mentioned in the issue
    - Used descriptive test names and comprehensive documentation